### PR TITLE
fix: remove unused AuditLog import

### DIFF
--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { getAuditLogs, getAuditActionTypes } from "@/lib/audit";
-import type { ApiResponse, AuditLog } from "@/types";
+import type { ApiResponse } from "@/types";
 
 interface AuditLogWithUser {
   id: string;


### PR DESCRIPTION
Removes unused import that was causing a lint warning.